### PR TITLE
chore: cost safety rails (tagging, audit, destroy)

### DIFF
--- a/docs/cost.md
+++ b/docs/cost.md
@@ -1,0 +1,56 @@
+# Cost Controls (Dev Environment)
+
+This repo provisions AWS infrastructure that can generate ongoing costs.
+This document explains what costs money, how to shut everything down, and how to verify nothing is still running.
+
+## What costs money (primary drivers)
+
+### Always-on / hourly
+- **EKS control plane**: billed while the cluster exists (even if nodes are 0).
+- **NAT Gateway**: hourly + data processing (often the sneaky bill).
+- **EC2 worker nodes**: hourly.
+- **Load balancers** (ALB/NLB): hourly + usage (later).
+
+### Usage-based / can grow
+- **EBS volumes / snapshots**: storage billed.
+- **CloudWatch Logs**: ingestion + retention (can surprise you).
+- **S3**: storage + requests (state bucket is usually negligible).
+
+## Resource tagging policy (required)
+All resources created by Terraform MUST be tagged via provider `default_tags`:
+
+- Project=ReplicaSafeEKS
+- Env=dev
+- Owner=admin-farouq
+- ManagedBy=terraform
+
+Rationale:
+- Fast cleanup and filtering
+- Cost attribution
+- Professional hygiene signal
+
+## OFF switch (end-of-session shutdown)
+
+### Destroy dev environment
+From repo root:
+```bash
+./scripts/destroy-dev.sh
+```
+
+## What remains after shutdown (expected)
+- Terraform state backend (S3 bucket + dynamoDB lock table) - near-zero cost. Everything else should be destroyed.
+
+## Verification checklist (prove nothing is running)
+After destroy, verify in using a cronjob that these are gone:
+- EKS cluster ( and node groups)
+- VPC created for the project
+- NAT Gateway(s)
+- EC2 instances 
+- load balancers
+- EBS volumes created by the cluster (if any)
+
+## Daily discipline checklist 
+- Apply only when actively working
+- Verfy and capture evidence 
+- Destroy at end of session
+- Check Billing / Cost Explorer weekly 

--- a/infra/_temlates/provider_aws.tf
+++ b/infra/_temlates/provider_aws.tf
@@ -1,0 +1,22 @@
+terraform {
+    required_version = "~> 1.7.5"
+    required_providers {
+        aws = {
+            source = "hashicorp/aws
+            version = "~> 5.0"
+        }
+    }
+}
+
+provider "aws" {
+    region = "eu-west-3"
+
+    default_tags {
+        tags = {
+            Project ="ReplicaSafeEKS"
+            Env = "dev"
+            Owner = "admin-farouq"
+            ManagedBy = "Terraform"
+        }
+    }
+}

--- a/scripts/cost-audit.sh
+++ b/scripts/cost-audit.sh
@@ -1,0 +1,98 @@
+set -euo pipefail
+
+REGION="${AWS_DEFAULT_REGION:-eu-west-3}"
+PROJECT_TAG="${PROJECT_TAG:-ReplicaSafeEKS}"
+ENV_TAG="${AWS_PROFILE:-dev}"
+
+echo "==> cost audit (read-only)"
+echo "Region: ${REGION}"
+echo "Project tag: ${PROJECT_TAG}"
+echo "Environment tag: ${ENV_TAG}"  
+
+aws() { command aws --region "${REGION}" "$@"; }
+
+section () {
+  echo
+  echo "----------------------------------"
+  echo "$1"
+  echo "----------------------------------"
+}
+
+# EKS clusters
+section "EKS clusters"
+aws eks list-clusters --output table || true
+
+# EC2 instances (filtered by tags)
+section "EC2 instances"
+aws ec2 describe-instances \
+    --filters \
+        "Name=tag:Project,Values=${PROJECT_TAG}" \
+        "Name=tag:Environment,Values=${ENV_TAG}" \
+        "Name=instance-state-name,Values=pending,running,stopping,stopped" \
+    --query "Reservations[].Instances[].{
+        Id: InstanceId,
+        State: State.Name,
+        Type: InstanceType,
+        AZ: Placement.AvailabilityZone,
+        Name: Tags[?Key=='Name']|[0].Value
+    }" \
+    --output table || true
+
+# NAT Gateways 
+section "NAT Gateways (all)"
+
+aws ec2 describe-nat-gateways \
+    --filter "Name=state,Values=available,pending" \
+    --query "NatGateways[].{
+        Id:NatGatewayID,
+        State:State,
+        Subnet:SubnetId,
+        Vpc:VpcId,
+        PublicIp:NatGatewayAddresses[0].PublicIp
+    }" \
+    --output table || true
+
+# Load Balancers
+section "Load Balancers (ELBv2: ALB/NLB)"
+aws elbv2 describe-load-balancers \
+    --query "LoadBalancers[].{
+        Name:LoadBalancerName,
+        Type:Type,
+        State:State.Code,
+        Scheme:Scheme,
+        DNSName:DNSName
+    }" \
+    --output table || true
+
+# EBS volumes (filtered by tags)
+section "EBS volumes"
+aws ec2 describe-volumes \
+    --filters \
+        "Name=tag:Project,Values=${PROJECT_TAG}" \
+        "Name=tag:Environment,Values=${ENV_TAG}" \
+    --query "Volumes[].{
+        Id:VolumeId,
+        State:State,
+        Type:VolumeType,
+        SizeGB:Size,
+        AZ:AvailabilityZone 
+    }" \
+    --output table || true
+
+# RDS instances (filtered by tags)
+section "RDS instances"
+aws rds describe-db-instances \
+    --query "Volumes[].{
+        Id:VolumeId,
+        State:State,
+        Type:VolumeType,
+        SizeGB:Size,
+        AZ:AvailabilityZone
+    }" \
+    --output table || true
+
+echo 
+echo "==> Done."
+echo "If anything above exists when you're not working, destroy dev env:"
+echo "  ./scripts/destroy-dev-env.sh"
+

--- a/scripts/destroy-dev.sh
+++ b/scripts/destroy-dev.sh
@@ -1,0 +1,24 @@
+set -euo pipefail 
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+ENV_DIR="${ROOT_DIR}/infra/environments/dev"
+
+if [[ ! -d "${ENV_DIR}" ]]; then
+    echo "ERROR: Environment directory '${ENV_DIR}' does not exist."
+    echo "Nothing to destroy."
+    exist 1
+fi
+
+if [[ ! -f "${ENV_DIR}/terraform.tfstate" && ! -d "${ENV_DIR}/.terraform" ]]; then
+    echo "No Terraform state found in '${ENV_DIR}'. Nothing to destroy."    
+    exit 0
+fi
+
+echo "Destroying infrastructure in environment form: ${ENV_DIR}"
+cd "${ENV_DIR}"
+
+terraform destroy -auto-approve
+
+echo "Infrastructure destroyed."
+echo "NOTE: Remote backend resources (S3 state bucket + DynamoDB lock table) are intentionally NOT destroyed."
+echo "Verify in AWS that EKS/VPC/NAT/EC2/LB are gone."


### PR DESCRIPTION
Closes #3

### What changed
- Added docs/cost.md with cost drivers + OFF switch + daily checklist
- Added scripts/cost-audit.sh (read-only audit)
- Added scripts/destroy-dev.sh (dev shutdown)
- Added Terraform provider tagging template (default_tags)
- Created AWS Budget alert (manual step)

### How to test
- ./scripts/cost-audit.sh
- ./scripts/destroy-dev.sh (expected to refuse until infra/environments/dev exists)
