### PR TITLE
feat/alerting and runbook

### DIFF
--- a/apps/api/main.py
+++ b/apps/api/main.py
@@ -3,6 +3,7 @@ import boto3
 from botocore.exceptions import ClientError
 from fastapi import FastAPI, HTTPException
 from pydantic import BaseModel
+from prometheus_fastapi_instrumentator import Instrumentator
 
 AWS_REGION = os.getenv("AWS_REGION", "eu-west-3")
 SQS_QUEUE_URL = os.getenv("SQS_QUEUE_URL", "")
@@ -12,6 +13,7 @@ if not SQS_QUEUE_URL:
 
 sqs = boto3.client("sqs", region_name=AWS_REGION)
 app = FastAPI(title="rsedp-demo-api")
+Instrumentator().instrument(app).expose(app)  # exposes /metrics
 
 class EventIn(BaseModel):
     type: str = "order.created"

--- a/apps/api/requirements.txt
+++ b/apps/api/requirements.txt
@@ -2,3 +2,4 @@ fastapi==0.115.0
 uvicorn[standard]==0.30.6
 boto3==1.35.0
 pydantic==2.8.2
+prometheus-fastapi-instrumentator==0.9.1

--- a/docs/runbooks/api-5xx.md
+++ b/docs/runbooks/api-5xx.md
@@ -1,0 +1,98 @@
+# Runbook: APIHighErrorRate / APIHighErrorRateCritical
+
+**Alert**: `APIHighErrorRate` (warning > 5%) / `APIHighErrorRateCritical` (critical > 10%)
+**SLO**: API availability 99.9% — 5xx rate must stay below 0.1% in steady state
+
+---
+
+## Symptom
+
+Prometheus alert fires:
+```
+APIHighErrorRate: API 5xx rate above 5%
+```
+Users see HTTP 503 responses from `POST /events`.
+
+---
+
+## Diagnosis
+
+### 1 — Check API pod health
+
+```bash
+kubectl -n demo-app get pods -l app=api
+kubectl -n demo-app logs -l app=api --tail=50
+```
+
+Look for:
+- `SQS unavailable:` — SQS connectivity or IRSA issue
+- `OOMKilled` in describe — memory limit hit
+
+### 2 — Check recent events
+
+```bash
+kubectl -n demo-app describe pod -l app=api | grep -A5 Events
+```
+
+### 3 — Check HPA / replica count
+
+```bash
+kubectl -n demo-app get hpa api
+kubectl -n demo-app get deploy api
+```
+
+If replicas are maxed (10/10) and CPU is 100%, the pod may be overloaded.
+
+### 4 — Check SQS / IRSA permissions
+
+```bash
+# Look for access denied errors
+kubectl -n demo-app logs -l app=api | grep -i "access\|denied\|403"
+```
+
+---
+
+## Likely Causes
+
+| Cause | Indicator |
+|-------|-----------|
+| SQS IRSA role revoked / misconfigured | `SQS unavailable: AccessDeniedException` in logs |
+| SQS queue deleted or URL changed | `SQS unavailable: AWS.SimpleQueueService.NonExistentQueue` |
+| Pod OOMKilled, restarting mid-request | Repeated pod restarts, `OOMKilled` in describe |
+| HPA maxed out, pod under severe load | `replicas: 10/10`, CPU 100% |
+
+---
+
+## Safe Mitigations
+
+### IRSA / SQS permission issue
+```bash
+# Verify the SA has the correct IAM role annotation
+kubectl -n demo-app describe sa demo-api
+
+# Re-apply to pick up any Terraform changes
+kubectl -n demo-app rollout restart deployment/api
+```
+
+### OOMKilled — raise memory limit temporarily
+```bash
+kubectl -n demo-app set resources deployment/api \
+  --limits=memory=1Gi --requests=memory=256Mi
+```
+
+### Roll back a bad deployment
+```bash
+kubectl -n demo-app rollout undo deployment/api
+kubectl -n demo-app rollout status deployment/api
+```
+
+---
+
+## Stop the Bleeding
+
+If the API is returning 100% errors and rollback doesn't help, route traffic away:
+```bash
+# Scale to zero if an ALB/Ingress is in front (stops new traffic hitting broken pods)
+kubectl -n demo-app scale deployment/api --replicas=0
+# Then investigate before scaling back up
+```

--- a/docs/runbooks/api-latency.md
+++ b/docs/runbooks/api-latency.md
@@ -1,0 +1,96 @@
+# Runbook: APIHighLatency
+
+**Alert**: `APIHighLatency` (warning — p95 > 500 ms for 5 minutes)
+**SLO**: API p95 latency < 500 ms
+
+---
+
+## Symptom
+
+Prometheus alert fires:
+```
+APIHighLatency: API p95 latency above 500 ms
+```
+Users may experience slow responses on `POST /events`.
+
+---
+
+## Diagnosis
+
+### 1 — Check current latency in Grafana / Prometheus
+
+```promql
+histogram_quantile(0.95,
+  sum(rate(http_request_duration_seconds_bucket{namespace="demo-app"}[5m])) by (le)
+)
+```
+
+### 2 — Check replica count and CPU
+
+```bash
+kubectl -n demo-app get hpa api
+kubectl -n demo-app top pods -n demo-app -l app=api
+```
+
+If HPA has not yet scaled up, CPU may be near the threshold (70% of 50m = 35m).
+
+### 3 — Check SQS send latency
+
+```bash
+kubectl -n demo-app logs -l app=api --tail=100 | grep -i "sqs\|send"
+```
+
+Long SQS `send_message` calls increase overall request duration.
+
+### 4 — Check for GC / memory pressure
+
+```bash
+kubectl -n demo-app describe pods -l app=api | grep -E "OOM|Killed|Memory"
+```
+
+---
+
+## Likely Causes
+
+| Cause | Indicator |
+|-------|-----------|
+| Single replica under load before HPA fires | 1 replica, CPU near 35m, HPA `TARGETS` near 70% |
+| SQS SDK retrying due to throttling | Slow SQS calls in logs, AWS throttle errors |
+| Python GIL / uvicorn worker queue backup | Increasing memory, slow fan-out |
+| Cold start after scale-out | Latency spike during `AVAILABLE: 1/4` phase |
+
+---
+
+## Safe Mitigations
+
+### HPA has not fired yet — scale manually to unblock
+```bash
+kubectl -n demo-app scale deployment/api --replicas=3
+```
+(HPA will take control back once metrics normalise.)
+
+### SQS throttling — check if queue is saturated
+```bash
+aws sqs get-queue-attributes \
+  --queue-url "$SQS_QUEUE_URL" \
+  --attribute-names ApproximateNumberOfMessages \
+  --region eu-west-3
+```
+If queue is very large, the worker side may be the real problem — see `worker-lag.md`.
+
+### Roll back if the regression followed a deployment
+```bash
+kubectl -n demo-app rollout history deployment/api
+kubectl -n demo-app rollout undo deployment/api
+```
+
+---
+
+## Stop the Bleeding
+
+```bash
+# Temporarily raise maxReplicas in hpa.yaml and apply:
+kubectl -n demo-app patch hpa api \
+  --type=merge -p '{"spec":{"maxReplicas":20}}'
+```
+Revert after the incident with `kubectl apply -f manifests/demo-app/hpa.yaml`.

--- a/docs/runbooks/crashlooping.md
+++ b/docs/runbooks/crashlooping.md
@@ -1,0 +1,119 @@
+# Runbook: PodCrashLooping
+
+**Alert**: `PodCrashLooping` (critical — any pod in demo-app is in CrashLoopBackOff for 5+ minutes)
+
+---
+
+## Symptom
+
+```
+PodCrashLooping: Pod worker-abc123 / worker is crash-looping
+```
+
+The pod is in `CrashLoopBackOff` — Kubernetes is restarting it with exponential backoff
+because the container exits immediately after starting.
+
+---
+
+## Diagnosis
+
+### 1 — Identify which pod and container
+
+```bash
+kubectl -n demo-app get pods
+# Look for STATUS=CrashLoopBackOff or high RESTARTS count
+```
+
+### 2 — Read current and previous logs
+
+```bash
+POD=<pod-name>
+kubectl -n demo-app logs $POD
+kubectl -n demo-app logs $POD --previous   # logs from the last crash
+```
+
+The crash message is almost always in the last few lines of `--previous`.
+
+### 3 — Describe the pod for exit codes and events
+
+```bash
+kubectl -n demo-app describe pod $POD
+```
+
+Key fields:
+- `Exit Code` — 1 = application error, 137 = OOMKilled, 139 = segfault
+- `Reason: OOMKilled` — memory limit hit
+- `Events:` section — shows if it was evicted or a liveness probe killed it
+
+### 4 — Check recent config/secret changes
+
+```bash
+kubectl -n demo-app get events --sort-by='.lastTimestamp' | tail -20
+git log --oneline -10   # check if a deployment happened recently
+```
+
+---
+
+## Likely Causes by Exit Code
+
+| Exit Code | Meaning | Common Cause |
+|-----------|---------|--------------|
+| 1 | Application error | Missing env var, bad config, startup validation failed |
+| 137 | OOMKilled | Memory limit too low |
+| 139 | Segfault | Rare in Python — usually a C extension issue |
+
+### Application startup failures (exit 1) — worker
+The worker validates environment on start:
+```python
+if not SQS_QUEUE_URL: raise SystemExit("SQS_QUEUE_URL not set")
+if not PGPASSWORD: raise SystemExit("PGPASSWORD not set")
+if WORKER_MODE not in ("idempotent", "non-idempotent"): raise SystemExit(...)
+```
+Check the Secret:
+```bash
+kubectl -n demo-app get secret demo-app-secrets -o yaml
+```
+
+### Application startup failures (exit 1) — API
+```python
+if not SQS_QUEUE_URL: raise SystemExit("SQS_QUEUE_URL not set")
+```
+
+---
+
+## Safe Mitigations
+
+### Bad env var / secret — fix the Secret and rollout
+```bash
+# Edit the secret (base64-encode values)
+kubectl -n demo-app edit secret demo-app-secrets
+
+# Restart deployment to pick up new secret
+kubectl -n demo-app rollout restart deployment/<name>
+kubectl -n demo-app rollout status deployment/<name>
+```
+
+### OOMKilled — raise memory limit
+```bash
+kubectl -n demo-app set resources deployment/<name> \
+  --limits=memory=1Gi
+```
+
+### Bad deployment — rollback
+```bash
+kubectl -n demo-app rollout undo deployment/<name>
+kubectl -n demo-app rollout status deployment/<name>
+```
+
+---
+
+## Stop the Bleeding
+
+While the pod is in backoff, Kubernetes will keep retrying. To prevent resource churn
+while you diagnose:
+```bash
+# Scale to 0, fix the issue, scale back
+kubectl -n demo-app scale deployment/<name> --replicas=0
+# ... fix ...
+kubectl -n demo-app scale deployment/<name> --replicas=1
+```

--- a/docs/runbooks/postgres-down.md
+++ b/docs/runbooks/postgres-down.md
@@ -1,0 +1,117 @@
+# Runbook: PostgresDown
+
+**Alert**: `PostgresDown` (critical — postgres pod not ready for 2+ minutes)
+**SLO**: Postgres available 99.9% of time — all workers and API fail without it
+
+---
+
+## Symptom
+
+```
+PostgresDown: Postgres pod is not ready
+```
+
+Worker pods will log `DB connection lost, reconnecting` on every message. API requests
+succeed (they only talk to SQS) but events queue up without being processed.
+
+---
+
+## Diagnosis
+
+### 1 — Check pod status
+
+```bash
+kubectl -n demo-app get pod -l app=postgres
+kubectl -n demo-app describe pod -l app=postgres
+```
+
+Look at the `Events` section at the bottom of describe output.
+
+### 2 — Check logs
+
+```bash
+kubectl -n demo-app logs -l app=postgres --tail=100
+```
+
+Common patterns:
+- `data directory "/var/lib/postgresql/data/pgdata" has wrong ownership` — PVC permission issue
+- `FATAL: role "app" does not exist` — init script failed
+- `Out of memory: Kill process` — OOMKilled
+
+### 3 — Check PVC
+
+```bash
+kubectl -n demo-app get pvc
+kubectl -n demo-app describe pvc postgres-data
+```
+
+If the PVC is `Pending`, the StorageClass (`gp3`) could not provision a volume.
+
+### 4 — Check recent restarts
+
+```bash
+kubectl -n demo-app get pod -l app=postgres \
+  -o jsonpath='{.items[0].status.containerStatuses[0].restartCount}'
+```
+
+---
+
+## Likely Causes
+
+| Cause | Indicator |
+|-------|-----------|
+| OOMKilled | `OOMKilled` in describe `Last State`, restart count incrementing |
+| PVC unavailable / node rescheduled | PVC in Pending or pod stuck in Init |
+| Init script failed on first run | `role "app" does not exist`, pod restarts once |
+| Node pressure caused eviction | Events show `Evicted` |
+| Config/secret mismatch | `password authentication failed for user "app"` in logs |
+
+---
+
+## Safe Mitigations
+
+### OOMKilled — raise memory limit
+```bash
+kubectl -n demo-app set resources deployment/postgres \
+  --limits=memory=1Gi --requests=memory=512Mi
+```
+
+### Pod stuck after node reschedule — restart
+```bash
+kubectl -n demo-app rollout restart deployment/postgres
+kubectl -n demo-app rollout status deployment/postgres
+```
+
+### PVC lost (worst case) — check if data exists on the PV
+```bash
+kubectl -n demo-app get pv
+kubectl describe pv <PV_NAME>
+```
+
+If the PV still exists but is `Released`, patch reclaim policy and re-bind:
+```bash
+kubectl patch pv <PV_NAME> -p '{"spec":{"claimRef":null}}'
+# Then reapply the PVC manifest
+kubectl apply -f manifests/demo-app/postgres.yaml
+```
+
+### Secret mismatch — verify PGPASSWORD
+```bash
+kubectl -n demo-app get secret demo-app-secrets \
+  -o jsonpath='{.data.pg_password}' | base64 -d
+```
+Must match the password used when the Postgres data directory was initialised.
+
+---
+
+## Stop the Bleeding
+
+Workers will auto-reconnect once Postgres is healthy (the `psycopg.OperationalError`
+handler in `worker.py` loops on reconnect). No manual intervention needed on worker side.
+
+Monitor recovery:
+```bash
+kubectl -n demo-app get pod -l app=postgres -w
+# Once Running/Ready, watch worker logs:
+kubectl -n demo-app logs -f -l app=worker
+```

--- a/docs/runbooks/worker-lag.md
+++ b/docs/runbooks/worker-lag.md
@@ -1,0 +1,120 @@
+# Runbook: WorkerNotConsuming / WorkerSQSBacklogCritical
+
+**Alerts**:
+- `WorkerNotConsuming` (warning — 0 events processed for 5 minutes)
+- `WorkerSQSBacklogCritical` (critical — SQS depth > 50 for 5 minutes)
+
+**SLO**: SQS backlog < 50 messages at all times during load
+
+---
+
+## Symptom
+
+```
+WorkerNotConsuming: Worker processed 0 events in the last 5 minutes
+WorkerSQSBacklogCritical: SQS backlog above 50 messages for 5+ minutes
+```
+
+Events are queuing in SQS but not being written to the `events` DB table.
+
+---
+
+## Diagnosis
+
+### 1 — Check worker pods
+
+```bash
+kubectl -n demo-app get pods -l app=worker
+kubectl -n demo-app logs -l app=worker --tail=50
+```
+
+Look for:
+- `DB connection lost, reconnecting` — Postgres down
+- `ERROR processing message` — deserialization or constraint failure
+- `AccessDeniedException` — IRSA role issue
+
+### 2 — Check KEDA ScaledObject
+
+```bash
+kubectl -n demo-app get scaledobject worker
+kubectl -n demo-app describe scaledobject worker
+```
+
+If `READY: False`, KEDA cannot read the queue depth — likely an IRSA issue.
+
+### 3 — Check SQS queue depth directly
+
+```bash
+aws sqs get-queue-attributes \
+  --queue-url "$(kubectl -n demo-app get secret demo-app-secrets \
+    -o jsonpath='{.data.sqs_queue_url}' | base64 -d)" \
+  --attribute-names ApproximateNumberOfMessages \
+  --region eu-west-3
+```
+
+### 4 — Check Prometheus metric
+
+```promql
+rate(worker_events_processed_total{namespace="demo-app"}[5m])
+```
+
+If this is 0 with pods running, the worker loop is stuck (DB issue or SQS read blocking).
+
+### 5 — Check worker replicas vs maxReplicaCount
+
+```bash
+kubectl -n demo-app get deploy worker
+```
+
+If replicas = 10 (maxReplicaCount) and queue keeps growing, the worker is genuinely
+overwhelmed — `maxReplicaCount` may need raising or `queueLength` tuning.
+
+---
+
+## Likely Causes
+
+| Cause | Indicator |
+|-------|-----------|
+| Postgres down | `DB connection lost` in logs, `PostgresDown` alert co-fires |
+| IRSA role revoked (sqs-worker SA) | `AccessDeniedException` in logs, ScaledObject READY=False |
+| Worker in `non-idempotent` mode (WORKER_MODE env changed) | Logs show `BROKEN processed` |
+| maxReplicaCount hit, queue growing faster than workers drain | 10 replicas, queue depth increasing |
+| Worker pod stuck / deadlocked | Pods Running but 0 processed_total rate |
+
+---
+
+## Safe Mitigations
+
+### Postgres is down — see `postgres-down.md` runbook first
+
+### IRSA issue — restart pods to refresh credentials
+```bash
+kubectl -n demo-app rollout restart deployment/worker
+kubectl -n demo-app rollout status deployment/worker
+```
+
+### Worker mode accidentally set to non-idempotent
+```bash
+kubectl -n demo-app set env deployment/worker WORKER_MODE=idempotent
+```
+
+### Temporarily raise maxReplicaCount to drain the backlog
+```bash
+kubectl -n demo-app patch scaledobject worker \
+  --type=merge -p '{"spec":{"maxReplicaCount":20}}'
+# Revert after backlog clears:
+kubectl apply -f manifests/demo-app/keda-scaledobject.yaml
+```
+
+---
+
+## Stop the Bleeding
+
+If the queue is growing uncontrollably, pause the producer (API) temporarily:
+```bash
+kubectl -n demo-app scale deployment/api --replicas=0
+```
+Fix the worker issue, drain the queue, then restore:
+```bash
+kubectl -n demo-app scale deployment/api --replicas=1
+```

--- a/docs/sre/slo.md
+++ b/docs/sre/slo.md
@@ -1,0 +1,113 @@
+# SLO Definitions — demo-app
+
+This document defines the Service Level Objectives for the demo-app platform.
+Each SLO has a corresponding Prometheus alert in `manifests/monitoring/prometheusrule.yaml`
+and a runbook in `docs/runbooks/`.
+
+---
+
+## SLO 1 — API Availability
+
+| Field | Value |
+|-------|-------|
+| **Target** | 99.9% of requests return non-5xx per 30-day window |
+| **Error budget** | 0.1% ≈ 43 minutes/month |
+| **SLI** | `1 - (5xx requests / total requests)` over 30 days |
+
+**Prometheus expression (burn rate indicator):**
+```promql
+1 - (
+  sum(rate(http_request_duration_seconds_count{namespace="demo-app",status_code=~"5.."}[30d]))
+  /
+  sum(rate(http_request_duration_seconds_count{namespace="demo-app"}[30d]))
+)
+```
+
+**Alerting thresholds (fast-burn):**
+- Warning: 5xx rate > 5% for 2 min → `APIHighErrorRate`
+- Critical: 5xx rate > 10% for 1 min → `APIHighErrorRateCritical`
+
+**Why these thresholds?**
+At 10% error rate sustained for 1 minute you burn ~1.4 h of monthly error budget per hour.
+That rate needs paging. At 5% you are burning fast but may self-correct (e.g., brief SQS hiccup).
+
+---
+
+## SLO 2 — API Latency
+
+| Field | Value |
+|-------|-------|
+| **Target** | p95 request duration < 500 ms |
+| **Window** | 5-minute rolling evaluation |
+| **SLI** | `histogram_quantile(0.95, http_request_duration_seconds_bucket)` |
+
+**Prometheus expression:**
+```promql
+histogram_quantile(0.95,
+  sum(rate(http_request_duration_seconds_bucket{namespace="demo-app"}[5m])) by (le)
+)
+```
+
+**Alerting threshold:**
+- Warning: p95 > 500 ms for 5 min → `APIHighLatency`
+
+**Why 500 ms?**
+The API does two things: validate the payload and call `SQS.send_message`.
+A healthy SQS send in `eu-west-3` completes in < 20 ms. Anything above 500 ms
+indicates external pressure (load, throttling, or cold start after scale-out).
+
+---
+
+## SLO 3 — Worker Processing Lag
+
+| Field | Value |
+|-------|-------|
+| **Target** | SQS queue depth < 50 messages during any load period |
+| **Window** | 5-minute sustained breach |
+| **SLI** | `keda_scaler_metrics_value{scaledObject="worker"}` (KEDA exposes raw SQS depth) |
+
+**Prometheus expression:**
+```promql
+keda_scaler_metrics_value{scaledObject="worker", namespace="demo-app"}
+```
+
+**Alerting thresholds:**
+- Warning (not consuming): `rate(worker_events_processed_total[5m]) == 0` for 5 min → `WorkerNotConsuming`
+- Critical (backlog): queue depth > 50 for 5 min → `WorkerSQSBacklogCritical`
+
+**Why 50 messages?**
+With `queueLength: 5` and `maxReplicaCount: 10` the cluster can drain 10 × (batch of 10) = 100
+messages per poll cycle (~15 s). A depth > 50 that persists 5 minutes means KEDA has maxed out
+replicas and the worker is still falling behind — the root cause needs investigation.
+
+---
+
+## SLO 4 — Data Store (Postgres) Availability
+
+| Field | Value |
+|-------|-------|
+| **Target** | Postgres pod ready 99.9% of time |
+| **Error budget** | ~43 minutes/month |
+| **SLI** | `kube_pod_container_status_ready{pod=~"postgres.*"}` (kube-state-metrics) |
+
+**Alerting threshold:**
+- Critical: postgres not ready for 2 min → `PostgresDown`
+
+**Why 2 minutes?**
+The worker reconnects immediately on `OperationalError`. A brief pod restart (< 30 s) does
+not constitute an SLO event. 2 minutes indicates a hard failure (OOMKill, PVC issue, eviction)
+that needs operator action.
+
+---
+
+## Alert → SLO → Runbook Map
+
+| Alert | Severity | SLO | Runbook |
+|-------|----------|-----|---------|
+| `APIHighErrorRate` | warning | SLO 1 | [api-5xx.md](../runbooks/api-5xx.md) |
+| `APIHighErrorRateCritical` | critical | SLO 1 | [api-5xx.md](../runbooks/api-5xx.md) |
+| `APIHighLatency` | warning | SLO 2 | [api-latency.md](../runbooks/api-latency.md) |
+| `WorkerNotConsuming` | warning | SLO 3 | [worker-lag.md](../runbooks/worker-lag.md) |
+| `WorkerSQSBacklogCritical` | critical | SLO 3 | [worker-lag.md](../runbooks/worker-lag.md) |
+| `PodCrashLooping` | critical | all | [crashlooping.md](../runbooks/crashlooping.md) |
+| `PostgresDown` | critical | SLO 4 | [postgres-down.md](../runbooks/postgres-down.md) |

--- a/manifests/demo-app/api.yaml
+++ b/manifests/demo-app/api.yaml
@@ -12,6 +12,10 @@ spec:
     metadata:
       labels:
         app: api
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "8080"
+        prometheus.io/path: "/metrics"
     spec:
       serviceAccountName: demo-api   # IRSA SA: sqs:SendMessage only (see addon_irsa_sqs_api.tf)
       containers:

--- a/manifests/monitoring/alertmanager-config.yaml
+++ b/manifests/monitoring/alertmanager-config.yaml
@@ -1,0 +1,75 @@
+# AlertmanagerConfig — namespace-scoped routing for demo-app alerts.
+# Prometheus Operator merges this into the global Alertmanager config automatically.
+#
+# Replace SLACK_WEBHOOK_URL with your actual webhook before deploying:
+#   kubectl -n demo-app create secret generic alertmanager-slack \
+#     --from-literal=url=https://hooks.slack.com/services/XXX/YYY/ZZZ
+#
+# Then update webhookConfigs[].httpConfig.bearerTokenSecret below.
+apiVersion: monitoring.coreos.com/v1alpha1
+kind: AlertmanagerConfig
+metadata:
+  name: demo-app
+  namespace: demo-app
+  labels:
+    alertmanagerConfig: demo-app
+spec:
+  route:
+    # Group alerts by alert name and namespace so related firings arrive together.
+    groupBy: ["alertname", "namespace"]
+    groupWait: 30s       # wait 30 s before sending the first notification in a group
+    groupInterval: 5m    # how long to wait before sending an updated notification
+    repeatInterval: 12h  # resend if still firing after 12 h
+    receiver: slack-warning
+
+    routes:
+      # Critical alerts: short groupWait, repeat every hour
+      - matchers:
+          - name: severity
+            value: critical
+        receiver: slack-critical
+        groupWait: 10s
+        repeatInterval: 1h
+
+      # Warning alerts: standard 30 s groupWait, repeat every 4 h
+      - matchers:
+          - name: severity
+            value: warning
+        receiver: slack-warning
+        groupWait: 30s
+        repeatInterval: 4h
+
+  receivers:
+    - name: slack-critical
+      slackConfigs:
+        - apiURL:
+            # Store the webhook URL in a k8s Secret, not inline.
+            name: alertmanager-slack
+            key: url
+          channel: "#alerts-critical"
+          sendResolved: true
+          title: |-
+            [{{ .Status | toUpper }}{{ if eq .Status "firing" }}:{{ .Alerts.Firing | len }}{{ end }}] {{ .CommonLabels.alertname }}
+          text: |-
+            {{ range .Alerts }}
+            *Alert:* {{ .Annotations.summary }}
+            *Severity:* {{ .Labels.severity }}
+            *Description:* {{ .Annotations.description }}
+            *Runbook:* {{ .Annotations.runbook_url }}
+            {{ end }}
+
+    - name: slack-warning
+      slackConfigs:
+        - apiURL:
+            name: alertmanager-slack
+            key: url
+          channel: "#alerts-warning"
+          sendResolved: true
+          title: |-
+            [{{ .Status | toUpper }}{{ if eq .Status "firing" }}:{{ .Alerts.Firing | len }}{{ end }}] {{ .CommonLabels.alertname }}
+          text: |-
+            {{ range .Alerts }}
+            *Alert:* {{ .Annotations.summary }}
+            *Severity:* {{ .Labels.severity }}
+            *Runbook:* {{ .Annotations.runbook_url }}
+            {{ end }}

--- a/manifests/monitoring/prometheusrule.yaml
+++ b/manifests/monitoring/prometheusrule.yaml
@@ -1,0 +1,138 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: demo-app
+  namespace: demo-app
+  labels:
+    # kube-prometheus-stack picks up rules with these labels by default
+    prometheus: kube-prometheus
+    role: alert-rules
+spec:
+  groups:
+
+  # ── API alerts ────────────────────────────────────────────────────────────
+  - name: demo-app.api
+    rules:
+
+    - alert: APIHighErrorRate
+      # Fires when > 5% of API requests return 5xx for 2 consecutive minutes.
+      # Mapped to SLO 1 (99.9% availability). Warning gives time to investigate
+      # before the error budget burns too fast.
+      expr: |
+        sum(rate(http_request_duration_seconds_count{namespace="demo-app",status_code=~"5.."}[5m]))
+        /
+        sum(rate(http_request_duration_seconds_count{namespace="demo-app"}[5m]))
+        > 0.05
+      for: 2m
+      labels:
+        severity: warning
+        namespace: demo-app
+      annotations:
+        summary: "API 5xx rate above 5%"
+        description: >
+          {{ $value | humanizePercentage }} of API requests are returning 5xx.
+          Check SQS connectivity and pod logs.
+        runbook_url: "https://github.com/zoolaph/Replica-Safe-Autoscaling-Event-Driven-Platform-on-AWS-EKS/blob/main/docs/runbooks/api-5xx.md"
+
+    - alert: APIHighErrorRateCritical
+      # Page immediately when 10%+ of requests are failing — SLO breach imminent.
+      expr: |
+        sum(rate(http_request_duration_seconds_count{namespace="demo-app",status_code=~"5.."}[5m]))
+        /
+        sum(rate(http_request_duration_seconds_count{namespace="demo-app"}[5m]))
+        > 0.10
+      for: 1m
+      labels:
+        severity: critical
+        namespace: demo-app
+      annotations:
+        summary: "API 5xx rate above 10% — SLO breach imminent"
+        description: >
+          {{ $value | humanizePercentage }} of API requests are returning 5xx.
+        runbook_url: "https://github.com/zoolaph/Replica-Safe-Autoscaling-Event-Driven-Platform-on-AWS-EKS/blob/main/docs/runbooks/api-5xx.md"
+
+    - alert: APIHighLatency
+      # p95 > 500 ms sustained for 5 minutes. Maps to SLO 2.
+      expr: |
+        histogram_quantile(0.95,
+          sum(rate(http_request_duration_seconds_bucket{namespace="demo-app"}[5m])) by (le)
+        ) > 0.5
+      for: 5m
+      labels:
+        severity: warning
+        namespace: demo-app
+      annotations:
+        summary: "API p95 latency above 500 ms"
+        description: "p95 latency is {{ $value | humanizeDuration }}."
+        runbook_url: "https://github.com/zoolaph/Replica-Safe-Autoscaling-Event-Driven-Platform-on-AWS-EKS/blob/main/docs/runbooks/api-latency.md"
+
+  # ── Worker alerts ─────────────────────────────────────────────────────────
+  - name: demo-app.worker
+    rules:
+
+    - alert: WorkerNotConsuming
+      # Worker replicas are running but the processed counter has not moved in 5 m.
+      # This catches a hung/deadlocked worker that has not crashed (so PodCrashLooping
+      # would not fire).
+      expr: |
+        sum(rate(worker_events_processed_total{namespace="demo-app"}[5m])) == 0
+      for: 5m
+      labels:
+        severity: warning
+        namespace: demo-app
+      annotations:
+        summary: "Worker processed 0 events in the last 5 minutes"
+        description: "Worker pods are running but not writing to the DB. Check logs and SQS connectivity."
+        runbook_url: "https://github.com/zoolaph/Replica-Safe-Autoscaling-Event-Driven-Platform-on-AWS-EKS/blob/main/docs/runbooks/worker-lag.md"
+
+    - alert: WorkerSQSBacklogCritical
+      # KEDA exposes keda_scaler_metrics_value with the raw queue depth it reads
+      # from SQS. > 50 for 5 m means autoscaling is not keeping up.
+      expr: |
+        keda_scaler_metrics_value{scaledObject="worker", namespace="demo-app"} > 50
+      for: 5m
+      labels:
+        severity: critical
+        namespace: demo-app
+      annotations:
+        summary: "SQS backlog above 50 messages for 5+ minutes"
+        description: "Queue depth is {{ $value }}. Worker may be stuck or maxReplicaCount reached."
+        runbook_url: "https://github.com/zoolaph/Replica-Safe-Autoscaling-Event-Driven-Platform-on-AWS-EKS/blob/main/docs/runbooks/worker-lag.md"
+
+  # ── Infrastructure alerts ─────────────────────────────────────────────────
+  - name: demo-app.infra
+    rules:
+
+    - alert: PodCrashLooping
+      # Any container in demo-app in CrashLoopBackOff for 5 continuous minutes.
+      expr: |
+        kube_pod_container_status_waiting_reason{
+          reason="CrashLoopBackOff",
+          namespace="demo-app"
+        } > 0
+      for: 5m
+      labels:
+        severity: critical
+        namespace: demo-app
+      annotations:
+        summary: "Pod {{ $labels.pod }} / {{ $labels.container }} is crash-looping"
+        description: "CrashLoopBackOff detected. Check recent deployments and secret mounts."
+        runbook_url: "https://github.com/zoolaph/Replica-Safe-Autoscaling-Event-Driven-Platform-on-AWS-EKS/blob/main/docs/runbooks/crashlooping.md"
+
+    - alert: PostgresDown
+      # The postgres container has been not-ready for 2+ minutes.
+      # kube-state-metrics (enabled in observability/values.yaml) provides this metric.
+      expr: |
+        kube_pod_container_status_ready{
+          pod=~"postgres.*",
+          namespace="demo-app",
+          container="postgres"
+        } == 0
+      for: 2m
+      labels:
+        severity: critical
+        namespace: demo-app
+      annotations:
+        summary: "Postgres pod is not ready"
+        description: "The postgres container has been not-ready for 2+ minutes. All workers and API will fail."
+        runbook_url: "https://github.com/zoolaph/Replica-Safe-Autoscaling-Event-Driven-Platform-on-AWS-EKS/blob/main/docs/runbooks/postgres-down.md"


### PR DESCRIPTION
## Summary

- **Add Prometheus metrics to API** — `prometheus-fastapi-instrumentator` wired into FastAPI; pod annotations added so the existing Prometheus scrape config picks it up automatically
- **PrometheusRule** — 7 alerts across 3 groups (API, worker, infra); each alert carries `severity`, `summary`, `description`, and a `runbook_url`
- **AlertmanagerConfig** — namespace-scoped CRD routes `critical` → `#alerts-critical` and `warning` → `#alerts-warning` via Slack webhook (replace `alertmanager-slack` Secret with real URL before deploying)
- **5 runbooks** — copy-paste-ready diagnosis → likely causes → safe mitigations → stop-the-bleeding steps, all referencing real pod/service names in this stack
- **SLO doc** — 4 SLOs with PromQL expressions, error budgets, alerting thresholds, and rationale

Closes #54

## Alerts

| Alert | Severity | Trigger |
|-------|----------|---------|
| `APIHighErrorRate` | warning | 5xx rate > 5% for 2 min |
| `APIHighErrorRateCritical` | critical | 5xx rate > 10% for 1 min |
| `APIHighLatency` | warning | p95 > 500 ms for 5 min |
| `WorkerNotConsuming` | warning | 0 events processed in 5 min |
| `WorkerSQSBacklogCritical` | critical | SQS depth > 50 for 5 min |
| `PodCrashLooping` | critical | CrashLoopBackOff in `demo-app` |
| `PostgresDown` | critical | postgres pod not ready for 2 min |

## How to trigger alerts intentionally (Definition of Done)

**1 — Trigger `APIHighErrorRateCritical`**
```bash
# Revoke the demo-api IRSA role (or point SQS_QUEUE_URL at a fake URL)
kubectl -n demo-app set env deployment/api SQS_QUEUE_URL=https://fake
# All POST /events return 503; alert fires within ~1 min
# Watch it in Alertmanager:
kubectl -n monitoring port-forward svc/kube-prometheus-stack-alertmanager 9093
# Restore:
kubectl -n demo-app rollout undo deployment/api
